### PR TITLE
fix(verblijfplaatsbinnenland): leveren verblijfplaats.onderzoek bij verblijfplaatsBinnenland

### DIFF
--- a/features/persoon/verblijfplaats/fields.feature
+++ b/features/persoon/verblijfplaats/fields.feature
@@ -351,15 +351,17 @@ Regel: als één of meerdere (gegevensgroep) velden van een verblijfplaats wordt
     | inOnderzoek.datumIngangOnderzoek          | 20020701                  |
 
     Voorbeelden:
-    | aanduiding in onderzoek | fields                                                                        | type                          | veld naam 1       | veld waarde 1 | veld naam 2               | veld waarde 2 |
-    | 080000                  | verblijfplaats                                                                | hele categorie verblijfplaats | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
-    | 081100                  | verblijfplaats                                                                | hele groep adres              | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
-    | 081150                  | verblijfplaats.verblijfadres                                                  | aanduiding bij huisnummer     |                   |               |                           |               |
-    | 081130                  | verblijfplaats.datumVan                                                       | huisletter                    |                   |               |                           |               |
-    | 081160                  | verblijfplaats.verblijfadres.postcode,verblijfplaats.verblijfadres.huisnummer | postcode                      |                   |               |                           |               |
-    | 081020                  | verblijfplaats.nummeraanduidingIdentificatie                                  | gemeentedeel                  |                   |               |                           |               |
-    | 080910                  | verblijfplaats                                                                | gemeente van inschrijving     | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
-    | 081410                  | verblijfplaats.verblijfadres                                                  | land vanwaar ingeschreven     |                   |               |                           |               |
+    | aanduiding in onderzoek | fields                                                                        | type                                          | veld naam 1       | veld waarde 1 | veld naam 2               | veld waarde 2 |
+    | 080000                  | verblijfplaats                                                                | hele categorie verblijfplaats                 | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
+    | 081100                  | verblijfplaats                                                                | hele groep adres                              | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
+    | 081150                  | verblijfplaats.verblijfadres                                                  | aanduiding bij huisnummer                     |                   |               |                           |               |
+    | 081130                  | verblijfplaats.datumVan                                                       | huisletter                                    |                   |               |                           |               |
+    | 081160                  | verblijfplaats.verblijfadres.postcode,verblijfplaats.verblijfadres.huisnummer | postcode                                      |                   |               |                           |               |
+    | 081020                  | verblijfplaats.nummeraanduidingIdentificatie                                  | gemeentedeel                                  |                   |               |                           |               |
+    | 080910                  | verblijfplaats                                                                | gemeente van inschrijving                     | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
+    | 081410                  | verblijfplaats.verblijfadres                                                  | land vanwaar ingeschreven                     |                   |               |                           |               |
+    | 080000                  | verblijfplaatsBinnenland                                                      | hele categorie verblijfplaats                 | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
+    | 089999                  | verblijfplaatsBinnenland.adresseerbaarObjectIdentificatie                     | indicatie vastgesteld verblijft niet op adres |                   |               |                           |               |
 
   Abstract Scenario: '<type>' van een locatie is in onderzoek en één of meerdere velden wordt gevraagd met field pad '<fields>'
     Gegeven adres 'A1' heeft de volgende gegevens
@@ -384,14 +386,16 @@ Regel: als één of meerdere (gegevensgroep) velden van een verblijfplaats wordt
     | inOnderzoek.datumIngangOnderzoek          | 20020701                    |
 
     Voorbeelden:
-    | aanduiding in onderzoek | fields                                                                                | type                          | veld naam 1       | veld waarde 1 | veld naam 2               | veld waarde 2 |
-    | 080000                  | verblijfplaats                                                                        | hele categorie verblijfplaats | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
-    | 081200                  | verblijfplaats                                                                        | hele groep locatie            | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
-    | 081210                  | verblijfplaats.verblijfadres                                                          | locatiebeschrijving           |                   |               |                           |               |
-    | 088510                  | verblijfplaats.verblijfadres.locatiebeschrijving,verblijfplaats.datumIngangGeldigheid | datum ingang geldigheid       |                   |               |                           |               |
-    | 081020                  | verblijfplaats.verblijfadres.locatiebeschrijving                                      | gemeentedeel                  |                   |               |                           |               |
-    | 080910                  | verblijfplaats                                                                        | gemeente van inschrijving     | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
-    | 081410                  | verblijfplaats.verblijfadres                                                          | land vanwaar ingeschreven     |                   |               |                           |               |
+    | aanduiding in onderzoek | fields                                                                                | type                                          | veld naam 1       | veld waarde 1 | veld naam 2               | veld waarde 2 |
+    | 080000                  | verblijfplaats                                                                        | hele categorie verblijfplaats                 | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
+    | 081200                  | verblijfplaats                                                                        | hele groep locatie                            | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
+    | 081210                  | verblijfplaats.verblijfadres                                                          | locatiebeschrijving                           |                   |               |                           |               |
+    | 088510                  | verblijfplaats.verblijfadres.locatiebeschrijving,verblijfplaats.datumIngangGeldigheid | datum ingang geldigheid                       |                   |               |                           |               |
+    | 081020                  | verblijfplaats.verblijfadres.locatiebeschrijving                                      | gemeentedeel                                  |                   |               |                           |               |
+    | 080910                  | verblijfplaats                                                                        | gemeente van inschrijving                     | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
+    | 081410                  | verblijfplaats.verblijfadres                                                          | land vanwaar ingeschreven                     |                   |               |                           |               |
+    | 080000                  | verblijfplaatsBinnenland                                                              | hele categorie verblijfplaats                 | functieAdres.code | W             | functieAdres.omschrijving | woonadres     |
+    | 089999                  | verblijfplaatsBinnenland.verblijfadres                                                | indicatie vastgesteld verblijft niet op adres |                   |               |                           |               |
 
   Abstract Scenario: '<type>' van een verblijfplaats buitenland is in onderzoek en één of meerdere velden wordt gevraagd met field pad '<fields>'
     Gegeven de persoon met burgerservicenummer '000000152' is ingeschreven op een buitenlands adres met de volgende gegevens

--- a/src/Rvig.HaalCentraalApi.Personen/Helpers/GbaPersonenApiHelper.cs
+++ b/src/Rvig.HaalCentraalApi.Personen/Helpers/GbaPersonenApiHelper.cs
@@ -78,7 +78,8 @@ public class GbaPersonenApiHelper : GbaPersonenApiHelperBase
 				|| fields.Any(field => field.Contains("adressering.land"))
 				|| fields.Any(field => field.Contains("adresseringBinnenland.adresregel"))
 				|| fields.Any(field => field.Equals("adressering"))
-				|| fields.Any(field => field.Equals("adresseringBinnenland")))
+				|| fields.Any(field => field.Equals("adresseringBinnenland"))
+				|| fields.Any(field => field.Contains("verblijfplaatsBinnenland")))
 			&& !fields.Contains("verblijfplaats") && !fields.Contains("verblijfplaats.inOnderzoek")
 			&& verblijfplaats.InOnderzoek != null)
 		{


### PR DESCRIPTION
Bij opvoeren van het veld`verblijfplaatsBinnenland` wordt nu het in-onderzoek deel ook meegeleverd. De [proxy](https://github.com/brp-api/Haal-Centraal-BRP-bevragen/pkgs/container/haal-centraal-brp-bevragen-proxy) levert dan `indicatieVastgesteldVerblijftNietOpAdres` zoals verwacht.
