### PR TITLE
fix: aanduidingNaamgebruik niet leveren

### DIFF
--- a/features/persoon/gezag/uitgebreid/fields.feature
+++ b/features/persoon/gezag/uitgebreid/fields.feature
@@ -133,8 +133,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | minderjarige.naam.voornamen                            | Jan Peter                |
         | minderjarige.naam.voorvoegsel                          | te                       |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                    |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                        |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam      |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                       |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                 |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat                |
@@ -145,8 +143,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | ouder.naam.voornamen                                   | Carolina                 |
         | ouder.naam.voorvoegsel                                 | te                       |
         | ouder.naam.geslachtsnaam                               | Hoogh                    |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                        |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam      |
         | ouder.naam.adellijkeTitelPredicaat.code                | JV                       |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw                |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat                |
@@ -159,8 +155,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | minderjarige.naam.voornamen                            | Alex                      |
         | minderjarige.naam.voorvoegsel                          | te                        |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                     |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                         |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam       |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                        |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                  |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat                 |
@@ -173,8 +167,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | naam.voornamen                            | Carolina            |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JV                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkvrouw           |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -186,8 +178,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | naam.voornamen                            | Karel               |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JH                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -200,8 +190,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | minderjarige.naam.voornamen                            | Arie                |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -212,8 +200,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | ouder.naam.voornamen                                   | Karel               |
         | ouder.naam.voorvoegsel                                 | te                  |
         | ouder.naam.geslachtsnaam                               | Hoogh               |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                   |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | ouder.naam.adellijkeTitelPredicaat.code                | JH                  |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer            |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -223,8 +209,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | derde.naam.voornamen                                   | Carolina            |
         | derde.naam.voorvoegsel                                 | te                  |
         | derde.naam.geslachtsnaam                               | Hoogh               |
-        | derde.naam.aanduidingNaamgebruik.code                  | E                   |
-        | derde.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | derde.naam.adellijkeTitelPredicaat.code                | JV                  |
         | derde.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw           |
         | derde.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -238,8 +222,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | minderjarige.naam.voornamen                            | Piet                |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -253,8 +235,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | minderjarige.naam.voornamen                            | Hendrik Jan         |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -267,8 +247,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | naam.voornamen                            | Carolina            |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JV                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkvrouw           |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -281,8 +259,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | minderjarige.naam.voornamen                            | Bas                 |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -346,8 +322,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | minderjarige.naam.voornamen                            | Jan Peter                |
         | minderjarige.naam.voorvoegsel                          | te                       |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                    |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                        |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam      |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                       |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                 |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat                |
@@ -358,8 +332,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | ouder.naam.voornamen                                   | Carolina                 |
         | ouder.naam.voorvoegsel                                 | te                       |
         | ouder.naam.geslachtsnaam                               | Hoogh                    |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                        |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam      |
         | ouder.naam.adellijkeTitelPredicaat.code                | JV                       |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw                |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat                |
@@ -497,8 +469,6 @@ Functionaliteit: gezagsrelaties vragen met fields
         | minderjarige.naam.voornamen                            | Jan Peter           |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |

--- a/features/persoon/gezag/uitgebreid/gezag-meerderjarige.feature
+++ b/features/persoon/gezag/uitgebreid/gezag-meerderjarige.feature
@@ -61,8 +61,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Jan Peter                 |
         | minderjarige.naam.voorvoegsel                          | te                        |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                     |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                         |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam       |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                        |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                  |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat                 |
@@ -75,8 +73,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | naam.voornamen                            | Alex                |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JH                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -88,8 +84,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | naam.voornamen                            | Carolina            |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JV                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkvrouw           |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -140,8 +134,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Jan Peter                |
         | minderjarige.naam.voorvoegsel                          | te                       |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                    |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                        |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam      |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                       |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                 |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat                |
@@ -152,8 +144,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | ouder.naam.voornamen                                   | Alex                     |
         | ouder.naam.voorvoegsel                                 | te                       |
         | ouder.naam.geslachtsnaam                               | Hoogh                    |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                        |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam      |
         | ouder.naam.adellijkeTitelPredicaat.code                | JH                       |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer                 |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat                |
@@ -217,8 +207,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Jan Peter           |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -229,8 +217,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | ouder.naam.voornamen                                   | Alex                |
         | ouder.naam.voorvoegsel                                 | te                  |
         | ouder.naam.geslachtsnaam                               | Hoogh               |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                   |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | ouder.naam.adellijkeTitelPredicaat.code                | JH                  |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer            |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -240,8 +226,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | derde.naam.voornamen                                   | Carolina            |
         | derde.naam.voorvoegsel                                 | te                  |
         | derde.naam.geslachtsnaam                               | Hoogh               |
-        | derde.naam.aanduidingNaamgebruik.code                  | E                   |
-        | derde.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | derde.naam.adellijkeTitelPredicaat.code                | JV                  |
         | derde.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw           |
         | derde.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -311,8 +295,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Jan Peter           |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -323,8 +305,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | ouder.naam.voornamen                                   | Alex                |
         | ouder.naam.voorvoegsel                                 | te                  |
         | ouder.naam.geslachtsnaam                               | Hoogh               |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                   |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | ouder.naam.adellijkeTitelPredicaat.code                | JH                  |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer            |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -334,8 +314,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | derde.naam.voornamen                                   | Carolina            |
         | derde.naam.voorvoegsel                                 | te                  |
         | derde.naam.geslachtsnaam                               | Hoogh               |
-        | derde.naam.aanduidingNaamgebruik.code                  | E                   |
-        | derde.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | derde.naam.adellijkeTitelPredicaat.code                | JV                  |
         | derde.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw           |
         | derde.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -436,8 +414,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Jan Peter           |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -448,8 +424,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | ouder.naam.voornamen                                   | Carolina            |
         | ouder.naam.voorvoegsel                                 | te                  |
         | ouder.naam.geslachtsnaam                               | Hoogh               |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                   |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | ouder.naam.adellijkeTitelPredicaat.code                | JV                  |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw           |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -459,8 +433,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | derde.naam.voornamen                                   | Karel               |
         | derde.naam.voorvoegsel                                 | te                  |
         | derde.naam.geslachtsnaam                               | Hoogh               |
-        | derde.naam.aanduidingNaamgebruik.code                  | E                   |
-        | derde.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | derde.naam.adellijkeTitelPredicaat.code                | JH                  |
         | derde.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer            |
         | derde.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -473,8 +445,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Alex                |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -485,8 +455,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | ouder.naam.voornamen                                   | Carolina            |
         | ouder.naam.voorvoegsel                                 | te                  |
         | ouder.naam.geslachtsnaam                               | Hoogh               |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                   |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | ouder.naam.adellijkeTitelPredicaat.code                | JV                  |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw           |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -496,8 +464,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | derde.naam.voornamen                                   | Karel               |
         | derde.naam.voorvoegsel                                 | te                  |
         | derde.naam.geslachtsnaam                               | Hoogh               |
-        | derde.naam.aanduidingNaamgebruik.code                  | E                   |
-        | derde.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | derde.naam.adellijkeTitelPredicaat.code                | JH                  |
         | derde.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer            |
         | derde.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -679,8 +645,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Jan Peter           |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -691,8 +655,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | ouder.naam.voornamen                                   | Bert                |
         | ouder.naam.voorvoegsel                                 | te                  |
         | ouder.naam.geslachtsnaam                               | Hoogh               |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                   |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | ouder.naam.adellijkeTitelPredicaat.code                | JH                  |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer            |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -702,8 +664,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | derde.naam.voornamen                                   | Carolina            |
         | derde.naam.voorvoegsel                                 | te                  |
         | derde.naam.geslachtsnaam                               | Hoogh               |
-        | derde.naam.aanduidingNaamgebruik.code                  | E                   |
-        | derde.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | derde.naam.adellijkeTitelPredicaat.code                | JV                  |
         | derde.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw           |
         | derde.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -716,8 +676,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Alex                      |
         | minderjarige.naam.voorvoegsel                          | te                        |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                     |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                         |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam       |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                        |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                  |
         | minderjarige.geboorte.datum                            | morgen - 12 jaar          |
@@ -730,8 +688,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | naam.voornamen                            | Carolina            |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JV                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkvrouw           |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -743,8 +699,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | naam.voornamen                            | Karel               |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JH                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -1094,8 +1048,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Alex                |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -1174,8 +1126,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Alex                |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -1251,8 +1201,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Alex                |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -1357,8 +1305,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Jan Peter                 |
         | minderjarige.naam.voorvoegsel                          | te                        |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                     |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                         |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam       |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                        |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                  |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat                 |
@@ -1371,8 +1317,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | naam.voornamen                            | Carolina            |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JV                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkvrouw           |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -1384,8 +1328,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | naam.voornamen                            | Karel               |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JH                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -1398,8 +1340,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Alex                     |
         | minderjarige.naam.voorvoegsel                          | te                       |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                    |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                        |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam      |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                       |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                 |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat                |
@@ -1410,8 +1350,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | ouder.naam.voornamen                                   | Carolina                 |
         | ouder.naam.voorvoegsel                                 | te                       |
         | ouder.naam.geslachtsnaam                               | Hoogh                    |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                        |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam      |
         | ouder.naam.adellijkeTitelPredicaat.code                | JV                       |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw                |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat                |
@@ -1424,8 +1362,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | minderjarige.naam.voornamen                            | Arie                |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -1436,8 +1372,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | ouder.naam.voornamen                                   | Carolina            |
         | ouder.naam.voorvoegsel                                 | te                  |
         | ouder.naam.geslachtsnaam                               | Hoogh               |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                   |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | ouder.naam.adellijkeTitelPredicaat.code                | JV                  |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkvrouw           |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -1447,8 +1381,6 @@ Functionaliteit: gezagsrelaties van een meerderjarige
         | derde.naam.voornamen                                   | Jan                 |
         | derde.naam.voorvoegsel                                 | te                  |
         | derde.naam.geslachtsnaam                               | Hoogh               |
-        | derde.naam.aanduidingNaamgebruik.code                  | E                   |
-        | derde.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | derde.naam.adellijkeTitelPredicaat.code                | JH                  |
         | derde.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer            |
         | derde.naam.adellijkeTitelPredicaat.soort               | predicaat           |

--- a/features/persoon/gezag/uitgebreid/gezag-minderjarige-uitgebreid.feature
+++ b/features/persoon/gezag/uitgebreid/gezag-minderjarige-uitgebreid.feature
@@ -34,8 +34,6 @@ Functionaliteit: gezagsrelaties van een minderjarige
         | minderjarige.naam.voornamen                            | Jan Peter           |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |

--- a/features/persoon/gezag/uitgebreid/gezag-minderjarige.feature
+++ b/features/persoon/gezag/uitgebreid/gezag-minderjarige.feature
@@ -52,8 +52,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | minderjarige.naam.voornamen                            | Jan Peter                 |
         | minderjarige.naam.voorvoegsel                          | te                        |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                     |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                         |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam       |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                        |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                  |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat                 |
@@ -66,8 +64,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | naam.voornamen                            | Alex                |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JH                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -79,8 +75,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | naam.voornamen                            | Carolina            |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JH                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -125,8 +119,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | minderjarige.naam.voornamen                            | Jan Peter                |
         | minderjarige.naam.voorvoegsel                          | te                       |
         | minderjarige.naam.geslachtsnaam                        | Hoogh                    |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                        |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam      |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                       |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer                 |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat                |
@@ -137,8 +129,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | ouder.naam.voornamen                                   | Alex                     |
         | ouder.naam.voorvoegsel                                 | te                       |
         | ouder.naam.geslachtsnaam                               | Hoogh                    |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                        |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam      |
         | ouder.naam.adellijkeTitelPredicaat.code                | JH                       |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer                 |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat                |
@@ -202,8 +192,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | minderjarige.naam.voornamen                            | Jan Peter           |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -214,8 +202,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | ouder.naam.voornamen                                   | Alex                |
         | ouder.naam.voorvoegsel                                 | te                  |
         | ouder.naam.geslachtsnaam                               | Hoogh               |
-        | ouder.naam.aanduidingNaamgebruik.code                  | E                   |
-        | ouder.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | ouder.naam.adellijkeTitelPredicaat.code                | JH                  |
         | ouder.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer            |
         | ouder.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -225,8 +211,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | derde.naam.voornamen                                   | Carolina            |
         | derde.naam.voorvoegsel                                 | te                  |
         | derde.naam.geslachtsnaam                               | Hoogh               |
-        | derde.naam.aanduidingNaamgebruik.code                  | E                   |
-        | derde.naam.aanduidingNaamgebruik.omschrijving          | eigen geslachtsnaam |
         | derde.naam.adellijkeTitelPredicaat.code                | JH                  |
         | derde.naam.adellijkeTitelPredicaat.omschrijving        | jonkheer            |
         | derde.naam.adellijkeTitelPredicaat.soort               | predicaat           |
@@ -316,8 +300,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | minderjarige.naam.voornamen                            | Ali                 |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -355,8 +337,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | minderjarige.naam.voornamen                            | Ali                 |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -404,8 +384,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | minderjarige.naam.voornamen                            | Jan Peter           |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -419,8 +397,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | naam.voornamen                            | Alex                |
         | naam.voorvoegsel                          | te                  |
         | naam.geslachtsnaam                        | Hoogh               |
-        | naam.aanduidingNaamgebruik.code           | E                   |
-        | naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | naam.adellijkeTitelPredicaat.code         | JH                  |
         | naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | naam.adellijkeTitelPredicaat.soort        | predicaat           |
@@ -459,8 +435,6 @@ Functionaliteit: gezagsrelaties van een minderjarige(n)
         | minderjarige.naam.voornamen                            | Jan Peter           |
         | minderjarige.naam.voorvoegsel                          | te                  |
         | minderjarige.naam.geslachtsnaam                        | Hoogh               |
-        | minderjarige.naam.aanduidingNaamgebruik.code           | E                   |
-        | minderjarige.naam.aanduidingNaamgebruik.omschrijving   | eigen geslachtsnaam |
         | minderjarige.naam.adellijkeTitelPredicaat.code         | JH                  |
         | minderjarige.naam.adellijkeTitelPredicaat.omschrijving | jonkheer            |
         | minderjarige.naam.adellijkeTitelPredicaat.soort        | predicaat           |

--- a/src/Rvig.HaalCentraalApi.Personen/Mappers/GezagsrelatieMapper.cs
+++ b/src/Rvig.HaalCentraalApi.Personen/Mappers/GezagsrelatieMapper.cs
@@ -1,5 +1,6 @@
 ﻿using Rvig.HaalCentraalApi.Personen.ApiModels.BRP;
 using Rvig.HaalCentraalApi.Personen.ApiModels.Gezag;
+using Rvig.HaalCentraalApi.Shared.ApiModels.PersonenHistorieBase;
 
 namespace Rvig.HaalCentraalApi.Personen.Mappers
 {
@@ -88,9 +89,9 @@ namespace Rvig.HaalCentraalApi.Personen.Mappers
 
                 result.Add(new ApiModels.BRP.GezamenlijkGezag
                 {
-                    Ouder = ouder,
                     Derde = derde,
-                    Minderjarige = minderjarige
+                    Minderjarige = minderjarige,
+                    Ouder = ouder
                 });
             }
         }
@@ -105,8 +106,8 @@ namespace Rvig.HaalCentraalApi.Personen.Mappers
 
                 result.Add(new ApiModels.BRP.TweehoofdigOuderlijkGezag
                 {
-                    Ouders = ouders,
-                    Minderjarige = minderjarige
+                    Minderjarige = minderjarige,
+                    Ouders = ouders
                 });
             }
         }
@@ -120,8 +121,8 @@ namespace Rvig.HaalCentraalApi.Personen.Mappers
 
                 result.Add(new ApiModels.BRP.EenhoofdigOuderlijkGezag
                 {
-                    Ouder = ouder,
-                    Minderjarige = minderjarige
+                    Minderjarige = minderjarige,
+                    Ouder = ouder
                 });
             }
         }
@@ -138,8 +139,8 @@ namespace Rvig.HaalCentraalApi.Personen.Mappers
             return new ApiModels.BRP.GezagOuder
             {
                 Burgerservicenummer = persoon.Burgerservicenummer,
-                Naam = persoon.Naam,
-                Geslacht = persoon.Geslacht
+                Geslacht = persoon.Geslacht,
+                Naam = MapNaam(persoon)
             };
         }
 
@@ -155,13 +156,9 @@ namespace Rvig.HaalCentraalApi.Personen.Mappers
             return new ApiModels.BRP.Minderjarige
             {
                 Burgerservicenummer = persoon.Burgerservicenummer,
-                Naam = persoon.Naam,
-                Geboorte = persoon.Geboorte != null ? new Shared.ApiModels.PersonenHistorieBase.GbaGeboorteBeperkt()
-                {
-                    Datum = persoon.Geboorte?.Datum
-
-                } : null,
-                Geslacht = persoon.Geslacht
+                Geboorte = MapGeboorte(persoon),
+                Geslacht = persoon.Geslacht,
+                Naam = MapNaam(persoon),
             };
         }
 
@@ -171,15 +168,34 @@ namespace Rvig.HaalCentraalApi.Personen.Mappers
 
             if (persoon == null) return new ApiModels.BRP.Meerderjarige()
             {
-                Burgerservicenummer = bsn
+                Burgerservicenummer = bsn,
             };
 
             return new ApiModels.BRP.Meerderjarige
             {
                 Burgerservicenummer = persoon.Burgerservicenummer,
-                Naam = persoon.Naam,
-                Geslacht = persoon.Geslacht
+                Geslacht = persoon.Geslacht,
+                Naam = MapNaam(persoon),
             };
+        }
+
+        private static GbaNaamBasis? MapNaam(GbaPersoon persoon)
+        {
+            return persoon.Naam != null ? new GbaNaamBasis
+            {
+                Voornamen = persoon.Naam?.Voornamen,
+                AdellijkeTitelPredicaat = persoon.Naam?.AdellijkeTitelPredicaat,
+                Voorvoegsel = persoon.Naam?.Voorvoegsel,
+                Geslachtsnaam = persoon.Naam?.Geslachtsnaam
+            } : null;
+        }
+
+        private static GbaGeboorteBeperkt? MapGeboorte(GbaPersoon persoon)
+        {
+            return persoon.Geboorte != null ? new GbaGeboorteBeperkt()
+            {
+                Datum = persoon.Geboorte?.Datum
+            } : null;
         }
     }
 }


### PR DESCRIPTION
In de mapper werden alle naamvelden gemapt naar `GbaNaamBasis`. Echter, in dit object komt `aanduidingNaamgebruik `ook voor. Omdat `aanduidingNaamgebruik` niet vereist is voor het samenstellen van de volledige naam hoeft dat niet geleverd te worden. De mapper is aangepast zodat aanduiding naamgebruik voortaan niet meer voorkomt in de response. De betreffende features zijn ook bijgewerkt.